### PR TITLE
Avoid attaching multiple scopes at once

### DIFF
--- a/grammars/MagicPython.cson
+++ b/grammars/MagicPython.cson
@@ -61,7 +61,8 @@ repository:
   comments:
     patterns: [
       {
-        name: "comment.line.number-sign.python meta.typehint.comment.python"
+        name: "comment.line.number-sign.python"
+        contentName: "meta.typehint.comment.python"
         begin: '''
           (?x)
             (?:
@@ -75,6 +76,8 @@ repository:
         '''
         end: "(?:$|(?=\\#))"
         beginCaptures:
+          "0":
+            name: "meta.typehint.comment.python"
           "1":
             name: "comment.typehint.directive.notation.python"
         patterns: [
@@ -1241,15 +1244,17 @@ repository:
   "parameter-special":
     match: '''
       (?x)
-        (?: \\b (self)|(cls) \\b) \\s*(?:(,)|(?=\\)))
+        \\b ((self)|(cls)) \\b \\s*(?:(,)|(?=\\)))
       
     '''
     captures:
       "1":
-        name: "variable.parameter.function.language.python variable.parameter.function.language.special.self.python"
+        name: "variable.parameter.function.language.python"
       "2":
-        name: "variable.parameter.function.language.python variable.parameter.function.language.special.cls.python"
+        name: "variable.parameter.function.language.special.self.python"
       "3":
+        name: "variable.parameter.function.language.special.cls.python"
+      "4":
         name: "punctuation.separator.parameters.python"
   "parameter-with-default":
     begin: '''

--- a/grammars/MagicPython.tmLanguage
+++ b/grammars/MagicPython.tmLanguage
@@ -94,7 +94,9 @@
         <array>
           <dict>
             <key>name</key>
-            <string>comment.line.number-sign.python meta.typehint.comment.python</string>
+            <string>comment.line.number-sign.python</string>
+            <key>contentName</key>
+            <string>meta.typehint.comment.python</string>
             <key>begin</key>
             <string>(?x)
   (?:
@@ -109,6 +111,11 @@
             <string>(?:$|(?=\#))</string>
             <key>beginCaptures</key>
             <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>meta.typehint.comment.python</string>
+              </dict>
               <key>1</key>
               <dict>
                 <key>name</key>
@@ -1992,21 +1999,26 @@ it's not tokenized as ellipsis.
       <dict>
         <key>match</key>
         <string>(?x)
-  (?: \b (self)|(cls) \b) \s*(?:(,)|(?=\)))
+  \b ((self)|(cls)) \b \s*(?:(,)|(?=\)))
 </string>
         <key>captures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>variable.parameter.function.language.python variable.parameter.function.language.special.self.python</string>
+            <string>variable.parameter.function.language.python</string>
           </dict>
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>variable.parameter.function.language.python variable.parameter.function.language.special.cls.python</string>
+            <string>variable.parameter.function.language.special.self.python</string>
           </dict>
           <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>variable.parameter.function.language.special.cls.python</string>
+          </dict>
+          <key>4</key>
           <dict>
             <key>name</key>
             <string>punctuation.separator.parameters.python</string>

--- a/grammars/src/MagicPython.syntax.yaml
+++ b/grammars/src/MagicPython.syntax.yaml
@@ -89,7 +89,7 @@ repository:
   comments:
     patterns:
       - name: comment.line.number-sign.python
-              meta.typehint.comment.python
+        contentName: meta.typehint.comment.python
 
         begin: |
           (?x)
@@ -103,6 +103,7 @@ repository:
 
         end: (?:$|(?=\#))
         beginCaptures:
+          '0': {name: meta.typehint.comment.python}
           '1': {name: comment.typehint.directive.notation.python}
 
         patterns:
@@ -841,13 +842,12 @@ repository:
   parameter-special:
     match: |
       (?x)
-        (?: \b (self)|(cls) \b) \s*(?:(,)|(?=\)))
+        \b ((self)|(cls)) \b \s*(?:(,)|(?=\)))
     captures:
-      '1': {name: variable.parameter.function.language.python
-                  variable.parameter.function.language.special.self.python}
-      '2': {name: variable.parameter.function.language.python
-                  variable.parameter.function.language.special.cls.python}
-      '3': {name: punctuation.separator.parameters.python}
+      '1': {name: variable.parameter.function.language.python}
+      '2': {name: variable.parameter.function.language.special.self.python}
+      '3': {name: variable.parameter.function.language.special.cls.python}
+      '4': {name: punctuation.separator.parameters.python}
 
   parameter-with-default:
     begin: |


### PR DESCRIPTION
Sublime Text handles whitespace-separated scope list pretty well, but Atom (or the 'first-mate' library to be precise) would fail to do that.