### PR TITLE
Make file types consistent between grammars/ and package.json

### DIFF
--- a/grammars/MagicPython.cson
+++ b/grammars/MagicPython.cson
@@ -7,6 +7,7 @@ fileTypes: [
   "rpy"
   "pyw"
   "cpy"
+  "pyi"
   "SConstruct"
   "Sconstruct"
   "sconstruct"

--- a/grammars/MagicPython.tmLanguage
+++ b/grammars/MagicPython.tmLanguage
@@ -14,6 +14,7 @@
       <string>rpy</string>
       <string>pyw</string>
       <string>cpy</string>
+      <string>pyi</string>
       <string>SConstruct</string>
       <string>Sconstruct</string>
       <string>sconstruct</string>

--- a/grammars/src/MagicPython.syntax.yaml
+++ b/grammars/src/MagicPython.syntax.yaml
@@ -1,8 +1,9 @@
 ---
 name: MagicPython
 scopeName: source.python
-fileTypes: [py, py3, rpy, pyw, cpy, SConstruct,
-            Sconstruct, sconstruct, SConscript,
+# NOTE: remember to update package.json with VSCode file types.
+fileTypes: [py, py3, rpy, pyw, cpy, pyi,
+            SConstruct, Sconstruct, sconstruct, SConscript,
             gyp, gypi]
 first_line_match: ^#!/.*\bpython[\d\.]*\b
 firstLineMatch: ^#!/.*\bpython[\d\.]*\b

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "theme": "dark"
   },
   "contributes": {
-    "//": "This section is for VSCode",
+    "//": [
+      "This section is for VSCode.",
+      "NOTE: remember to update grammar/src/MagicPython.syntax.yaml, too."
+    ],
     "languages": [
       {
         "id": "python",
@@ -49,7 +52,9 @@
           ".SConstruct",
           ".Sconstruct",
           ".sconstruct",
-          ".SConscript"
+          ".SConscript",
+          ".gyp",
+          ".gypi"
         ]
       }
     ],


### PR DESCRIPTION
This made .pyi, .gyp, and .gypi available in all editors. I put comments there
to help others find the other file in the future. Would be nicer still to
automate this but I frankly don't have cycles for that now.

Test plan: ran `make test`, passed. Installed this package locally with `apm
link`, confirm new file types are visible.