### PR TITLE
Clean-up the grammar so that MagicRegExp does not have missing rules.

### DIFF
--- a/grammars/MagicPython.cson
+++ b/grammars/MagicPython.cson
@@ -252,11 +252,6 @@ repository:
     captures:
       "1":
         name: "keyword.control.flow.python"
-  codetags:
-    match: "(?:\\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\\b)"
-    captures:
-      "1":
-        name: "keyword.codetag.notation.python"
   "statement-keyword":
     patterns: [
       {
@@ -986,24 +981,6 @@ repository:
       }
       {
         include: "#fstring-formatting-singe-brace"
-      }
-    ]
-  "fstring-formatting-braces":
-    patterns: [
-      {
-        comment: "empty braces are illegal"
-        match: "({)(\\s*?)(})"
-        captures:
-          "1":
-            name: "constant.character.format.placeholder.other.python"
-          "2":
-            name: "invalid.illegal.brace.python"
-          "3":
-            name: "constant.character.format.placeholder.other.python"
-      }
-      {
-        name: "constant.character.escape.python"
-        match: "({{|}})"
       }
     ]
   "fstring-formatting-singe-brace":
@@ -1931,6 +1908,24 @@ repository:
         include: "#regexp-base-common"
       }
     ]
+  "fstring-formatting-braces":
+    patterns: [
+      {
+        comment: "empty braces are illegal"
+        match: "({)(\\s*?)(})"
+        captures:
+          "1":
+            name: "constant.character.format.placeholder.other.python"
+          "2":
+            name: "invalid.illegal.brace.python"
+          "3":
+            name: "constant.character.format.placeholder.other.python"
+      }
+      {
+        name: "constant.character.escape.python"
+        match: "({{|}})"
+      }
+    ]
   "regexp-base-common":
     patterns: [
       {
@@ -2066,6 +2061,11 @@ repository:
         include: "#regexp-escape-catchall"
       }
     ]
+  codetags:
+    match: "(?:\\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\\b)"
+    captures:
+      "1":
+        name: "keyword.codetag.notation.python"
   "comments-base":
     name: "comment.line.number-sign.python"
     begin: "(\\#)"

--- a/grammars/MagicPython.tmLanguage
+++ b/grammars/MagicPython.tmLanguage
@@ -404,19 +404,6 @@
           </dict>
         </dict>
       </dict>
-      <key>codetags</key>
-      <dict>
-        <key>match</key>
-        <string>(?:\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\b)</string>
-        <key>captures</key>
-        <dict>
-          <key>1</key>
-          <dict>
-            <key>name</key>
-            <string>keyword.codetag.notation.python</string>
-          </dict>
-        </dict>
-      </dict>
       <key>statement-keyword</key>
       <dict>
         <key>patterns</key>
@@ -1506,42 +1493,6 @@
           <dict>
             <key>include</key>
             <string>#fstring-formatting-singe-brace</string>
-          </dict>
-        </array>
-      </dict>
-      <key>fstring-formatting-braces</key>
-      <dict>
-        <key>patterns</key>
-        <array>
-          <dict>
-            <key>comment</key>
-            <string>empty braces are illegal</string>
-            <key>match</key>
-            <string>({)(\s*?)(})</string>
-            <key>captures</key>
-            <dict>
-              <key>1</key>
-              <dict>
-                <key>name</key>
-                <string>constant.character.format.placeholder.other.python</string>
-              </dict>
-              <key>2</key>
-              <dict>
-                <key>name</key>
-                <string>invalid.illegal.brace.python</string>
-              </dict>
-              <key>3</key>
-              <dict>
-                <key>name</key>
-                <string>constant.character.format.placeholder.other.python</string>
-              </dict>
-            </dict>
-          </dict>
-          <dict>
-            <key>name</key>
-            <string>constant.character.escape.python</string>
-            <key>match</key>
-            <string>({{|}})</string>
           </dict>
         </array>
       </dict>
@@ -2978,6 +2929,42 @@ indirectly through syntactic constructs
           </dict>
         </array>
       </dict>
+      <key>fstring-formatting-braces</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>comment</key>
+            <string>empty braces are illegal</string>
+            <key>match</key>
+            <string>({)(\s*?)(})</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>constant.character.format.placeholder.other.python</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>invalid.illegal.brace.python</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>constant.character.format.placeholder.other.python</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>constant.character.escape.python</string>
+            <key>match</key>
+            <string>({{|}})</string>
+          </dict>
+        </array>
+      </dict>
       <key>regexp-base-common</key>
       <dict>
         <key>patterns</key>
@@ -3187,6 +3174,19 @@ indirectly through syntactic constructs
             <string>#regexp-escape-catchall</string>
           </dict>
         </array>
+      </dict>
+      <key>codetags</key>
+      <dict>
+        <key>match</key>
+        <string>(?:\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\b)</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.codetag.notation.python</string>
+          </dict>
+        </dict>
       </dict>
       <key>comments-base</key>
       <dict>

--- a/grammars/MagicRegExp.cson
+++ b/grammars/MagicRegExp.cson
@@ -35,6 +35,24 @@ repository:
         include: "#regexp-base-common"
       }
     ]
+  "fstring-formatting-braces":
+    patterns: [
+      {
+        comment: "empty braces are illegal"
+        match: "({)(\\s*?)(})"
+        captures:
+          "1":
+            name: "constant.character.format.placeholder.other.python"
+          "2":
+            name: "invalid.illegal.brace.python"
+          "3":
+            name: "constant.character.format.placeholder.other.python"
+      }
+      {
+        name: "constant.character.escape.python"
+        match: "({{|}})"
+      }
+    ]
   "regexp-base-common":
     patterns: [
       {
@@ -170,6 +188,11 @@ repository:
         include: "#regexp-escape-catchall"
       }
     ]
+  codetags:
+    match: "(?:\\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\\b)"
+    captures:
+      "1":
+        name: "keyword.codetag.notation.python"
   "regexp-expression":
     patterns: [
       {

--- a/grammars/MagicRegExp.tmLanguage
+++ b/grammars/MagicRegExp.tmLanguage
@@ -58,6 +58,42 @@
           </dict>
         </array>
       </dict>
+      <key>fstring-formatting-braces</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>comment</key>
+            <string>empty braces are illegal</string>
+            <key>match</key>
+            <string>({)(\s*?)(})</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>constant.character.format.placeholder.other.python</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>invalid.illegal.brace.python</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>constant.character.format.placeholder.other.python</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>constant.character.escape.python</string>
+            <key>match</key>
+            <string>({{|}})</string>
+          </dict>
+        </array>
+      </dict>
       <key>regexp-base-common</key>
       <dict>
         <key>patterns</key>
@@ -267,6 +303,19 @@
             <string>#regexp-escape-catchall</string>
           </dict>
         </array>
+      </dict>
+      <key>codetags</key>
+      <dict>
+        <key>match</key>
+        <string>(?:\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\b)</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.codetag.notation.python</string>
+          </dict>
+        </dict>
       </dict>
       <key>regexp-expression</key>
       <dict>

--- a/grammars/src/MagicPython.syntax.yaml
+++ b/grammars/src/MagicPython.syntax.yaml
@@ -351,11 +351,6 @@ repository:
     captures:
       '1': {name: keyword.control.flow.python}
 
-  codetags:
-    match: (?:\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\b)
-    captures:
-      '1': {name: keyword.codetag.notation.python}
-
   statement-keyword:
     patterns:
       - name: storage.type.function.python
@@ -823,17 +818,6 @@ repository:
     patterns:
       - include: '#fstring-formatting-braces'
       - include: '#fstring-formatting-singe-brace'
-
-  fstring-formatting-braces:
-    patterns:
-      - comment: empty braces are illegal
-        match: ({)(\s*?)(})
-        captures:
-          '1': {name: constant.character.format.placeholder.other.python}
-          '2': {name: invalid.illegal.brace.python}
-          '3': {name: constant.character.format.placeholder.other.python}
-      - name: constant.character.escape.python
-        match: ({{|}})
 
   fstring-formatting-singe-brace:
     name: invalid.illegal.brace.python

--- a/grammars/src/regexp-common.inc.syntax.yaml
+++ b/grammars/src/regexp-common.inc.syntax.yaml
@@ -12,6 +12,17 @@ repository:
       - match: \{.*?\}
       - include: '#regexp-base-common'
 
+  fstring-formatting-braces:
+    patterns:
+      - comment: empty braces are illegal
+        match: ({)(\s*?)(})
+        captures:
+          '1': {name: constant.character.format.placeholder.other.python}
+          '2': {name: invalid.illegal.brace.python}
+          '3': {name: constant.character.format.placeholder.other.python}
+      - name: constant.character.escape.python
+        match: ({{|}})
+
   regexp-base-common:
     patterns:
       - name: support.other.match.any.regexp
@@ -109,4 +120,9 @@ repository:
       - include: '#regexp-escape-character'
       - include: '#regexp-escape-unicode'
       - include: '#regexp-escape-catchall'
+
+  codetags:
+    match: (?:\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\b)
+    captures:
+      '1': {name: keyword.codetag.notation.python}
 ...

--- a/test/atom-spec/python-re-spec.js
+++ b/test/atom-spec/python-re-spec.js
@@ -56,6 +56,23 @@ describe("Grammar Tests", function() {
       expect(tokens[4][3].scopes).toEqual(["source.regexp.python","comment.regexp","punctuation.comment.end.regexp"]);
     });
 
+  it("test/regexp/comments3.re", 
+    function() {
+      tokens = grammar.tokenizeLines("foo(?#NOTE:comment)bar")
+      expect(tokens[0][0].value).toBe("foo");
+      expect(tokens[0][0].scopes).toEqual(["source.regexp.python"]);
+      expect(tokens[0][1].value).toBe("(?#");
+      expect(tokens[0][1].scopes).toEqual(["source.regexp.python","comment.regexp","punctuation.comment.begin.regexp"]);
+      expect(tokens[0][2].value).toBe("NOTE");
+      expect(tokens[0][2].scopes).toEqual(["source.regexp.python","comment.regexp","keyword.codetag.notation.python"]);
+      expect(tokens[0][3].value).toBe(":comment");
+      expect(tokens[0][3].scopes).toEqual(["source.regexp.python","comment.regexp"]);
+      expect(tokens[0][4].value).toBe(")");
+      expect(tokens[0][4].scopes).toEqual(["source.regexp.python","comment.regexp","punctuation.comment.end.regexp"]);
+      expect(tokens[0][5].value).toBe("bar");
+      expect(tokens[0][5].scopes).toEqual(["source.regexp.python"]);
+    });
+
   it("test/regexp/conditional1.re", 
     function() {
       tokens = grammar.tokenizeLines("(<)?(\\w+@\\w+(?:\\.\\w+)+)(?(1)>|$)")

--- a/test/regexp/comments3.re
+++ b/test/regexp/comments3.re
@@ -1,0 +1,10 @@
+foo(?#NOTE:comment)bar
+
+
+
+foo           : source.regexp.python
+(?#           : comment.regexp, punctuation.comment.begin.regexp, source.regexp.python
+NOTE          : comment.regexp, keyword.codetag.notation.python, source.regexp.python
+:comment      : comment.regexp, source.regexp.python
+)             : comment.regexp, punctuation.comment.end.regexp, source.regexp.python
+bar           : source.regexp.python


### PR DESCRIPTION
This is basically fixing the issue of missing rules in MagicRegExp that @stoivo noticed.

Converting the grammar to sublime-syntax is still beyond the scope of this particular pull request.