### PR TITLE
Remove invalid first_line_match key

### DIFF
--- a/grammars/MagicPython.cson
+++ b/grammars/MagicPython.cson
@@ -19,7 +19,6 @@ fileTypes: [
   "Snakefile"
   "tac"
 ]
-first_line_match: "^#![ \\t]*/.*\\bpython[\\d\\.]*\\b"
 firstLineMatch: "^#![ \\t]*/.*\\bpython[\\d\\.]*\\b"
 uuid: "742deb57-6e38-4192-bed6-410746efd85d"
 patterns: [

--- a/grammars/MagicPython.tmLanguage
+++ b/grammars/MagicPython.tmLanguage
@@ -26,8 +26,6 @@
       <string>Snakefile</string>
       <string>tac</string>
     </array>
-    <key>first_line_match</key>
-    <string>^#![ \t]*/.*\bpython[\d\.]*\b</string>
     <key>firstLineMatch</key>
     <string>^#![ \t]*/.*\bpython[\d\.]*\b</string>
     <key>uuid</key>

--- a/grammars/src/MagicPython.syntax.yaml
+++ b/grammars/src/MagicPython.syntax.yaml
@@ -5,7 +5,6 @@ scopeName: source.python
 fileTypes: [py, py3, rpy, pyw, cpy, pyi,
             SConstruct, Sconstruct, sconstruct, SConscript,
             gyp, gypi, wsgi, kv, Snakefile, tac]
-first_line_match: ^#![ \t]*/.*\bpython[\d\.]*\b
 firstLineMatch: ^#![ \t]*/.*\bpython[\d\.]*\b
 uuid: 742deb57-6e38-4192-bed6-410746efd85d
 


### PR DESCRIPTION
This pull request removes the invalid `first_line_match` key from grammar files. I'm not sure if this is the old version of `firstLineMatch` or an error, but it's raising errors on GitHub.com (see github/linguist#3924 for further details).