### PR TITLE
Add support for Snakemake files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
           ".SConscript",
           ".gyp",
           ".gypi",
-          ".wsgi"
+          ".wsgi",
+          ".Snakefile",
+          ".smk"
         ]
       }
     ],


### PR DESCRIPTION
This PR adds support for Python syntax highlighting in .smk files, which are used by Snakemake.

Related to: https://github.com/atom/language-python/pull/216