### PR TITLE
Changing Try-Except... snippets to be Python 3 style (as instead of ,)

### DIFF
--- a/snippets/sublime/Try-Except-Else-Finally.sublime-snippet
+++ b/snippets/sublime/Try-Except-Else-Finally.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[try:
 	${1:pass}
-except${2: ${3:Exception}, ${4:e}}:
+except${2: ${3:Exception} as ${4:e}}:
 	${5:raise}
 else:
 	${6:pass}

--- a/snippets/sublime/Try-Except-Else.sublime-snippet
+++ b/snippets/sublime/Try-Except-Else.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[try:
 	${1:pass}
-except ${2:Exception}, ${3:e}:
+except ${2:Exception} as ${3:e}:
 	${4:raise $3}
 else:
 	${5:pass}]]></content>

--- a/snippets/sublime/Try-Except-Finally.sublime-snippet
+++ b/snippets/sublime/Try-Except-Finally.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[try:
 	${1:pass}
-except ${2:Exception}, ${3:e}:
+except ${2:Exception} as ${3:e}:
 	${4:raise $3}
 finally:
 	${5:pass}]]></content>

--- a/snippets/sublime/Try-Except.sublime-snippet
+++ b/snippets/sublime/Try-Except.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[try:
 	${1:pass}
-except ${2:Exception}, ${3:e}:
+except ${2:Exception} as ${3:e}:
 	${4:raise $3}]]></content>
     <tabTrigger>try</tabTrigger>
     <scope>source.python</scope>


### PR DESCRIPTION
The Try-Except snippets use Python 2 style exceptions (with a comma). These don't work in Python 3.

