### PR TITLE
Modify foldEndPattern in Atom settings

### DIFF
--- a/settings/atom.cson
+++ b/settings/atom.cson
@@ -35,7 +35,7 @@
     'autoIndentOnPaste': false
     'softTabs': true
     'tabLength': 4
-    'foldEndPattern': '^\\s*"""\\s*$'
+    'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|((async\\s+)?(def|with|for))|elif|else|except|finally|if|try|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'


### PR DESCRIPTION
(This is in conjunction with a similar PR sent to `language-python` https://github.com/atom/language-python/pull/274, though the text is modified slightly for MagicPython)

### Description of the Change

Add a value for `foldEndPattern` in the package settings. This improves the folding behavior for dictionaries, lists, and functions. It folds the entire logical syntax item instead of leaving the ending character on a separate line. It also improves the use of [Hydrogen](https://atom.io/packages/Hydrogen) when the ending `}`, `)`, or `]` is on a separate line and not indented.

Many other core Atom language grammars have a `foldEndPattern`; the regex used in this PR is taken from [`language-javascript`](https://github.com/atom/language-javascript/blob/df7a049ec5b6e866b1686c561ba8d8bb7c0de0c5/settings/language-javascript.cson#L5) because of the similarity in syntax used for data structures.

### Alternate Designs

The regex is `^\\s*\\}|^\\s*\\]|^\\s*\\)` in order to fold the end of dictionaries, lists, and functions/tuples, respectively.

The current `foldEndPattern` in MagicPython is `^\\s*"""\\s*$`. The `language-python` `foldEndPattern` [used to be the same](https://github.com/atom/language-python/pull/155) but was removed because the fold would include the beginning `"""`  here:
```py
if True:
    print(True)

"""
A string"""
```
Since Hydrogen uses Atom's fold regions to determine what code to send to the kernel, it also ran `"""`, which was [undesirable](https://github.com/nteract/hydrogen/issues/418).

### Benefits

1. Improve fold behavior by including the ending character (see screenshots below)

**Expanded**:
![image](https://user-images.githubusercontent.com/15164633/45392246-71299b80-b5f4-11e8-9f23-364da0a26b8c.png)

**Current fold behavior**:
![image](https://user-images.githubusercontent.com/15164633/45392284-a8984800-b5f4-11e8-8484-f91897382c85.png)

**New fold behavior**:
![image](https://user-images.githubusercontent.com/15164633/45392258-81417b00-b5f4-11e8-996f-71efdf30a178.png)

2. This would also improve behavior with the [Hydrogen](https://atom.io/packages/Hydrogen) package, as that uses Atom's fold regions to decide what block of code to send to the Jupyter kernel. A hacky solution to this was developed (https://github.com/nikitakit/hydrogen-python/pull/10, [code](https://github.com/nikitakit/hydrogen-python/pull/10/files#diff-16b7d75b70953cbf4755508170f2f24cR58)) in a Python-specific extension to Hydrogen, but the plugin's use is not widespread among all Hydrogen Python users.

**Current Hydrogen behavior with ending character on separate line**:
![image](https://user-images.githubusercontent.com/15164633/45392861-4260f480-b5f7-11e8-9120-ba292bcd707e.png)

**New Hydrogen behavior with ending character on separate line**:

![image](https://user-images.githubusercontent.com/15164633/45392910-818f4580-b5f7-11e8-8d02-e05ff1f06974.png)

### Possible Drawbacks

Those who prefer the current behavior could be disappointed? I can't think of any others.

### Applicable Issues

- https://github.com/MagicStack/MagicPython/issues/80
- https://github.com/nteract/hydrogen/issues/724
- https://github.com/nteract/hydrogen/issues/155
