### PR TITLE
Add an `update-test` make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ ci-test: release
 	] ; \
 		then echo "Error: package.version != git.tag" && exit 1 ; fi
 
+update-test:
+#	Run tests and overwrite the output
+	./node_modules/.bin/syntaxdev test --tests test/**/*.py --syntax grammars/src/MagicPython.syntax.yaml --overwrite-tests
+	./node_modules/.bin/syntaxdev test --tests test/**/*.re --syntax grammars/src/MagicRegExp.syntax.yaml --overwrite-tests
+
 test: ci-test
 	atom -t test/atom-spec
 


### PR DESCRIPTION
The `update-test` make target will automatically update the output of
any test that failed. This kind of bulk update is intended to be used
when the changes to scopes affect a large number of files. Of course, the
actual updated tests should still be reviewed for correctness.