### PR TITLE
constant.numeric.dec.python only has 2 capture groups

### DIFF
--- a/grammars/MagicPython.cson
+++ b/grammars/MagicPython.cson
@@ -676,8 +676,6 @@ repository:
         name: "storage.type.imaginary.number.python"
       "2":
         name: "invalid.illegal.dec.python"
-      "3":
-        name: "invalid.illegal.dec.python"
   "number-hex":
     name: "constant.numeric.hex.python"
     match: '''

--- a/grammars/MagicPython.tmLanguage
+++ b/grammars/MagicPython.tmLanguage
@@ -1034,11 +1034,6 @@ it's probably control flow like:
             <key>name</key>
             <string>invalid.illegal.dec.python</string>
           </dict>
-          <key>3</key>
-          <dict>
-            <key>name</key>
-            <string>invalid.illegal.dec.python</string>
-          </dict>
         </dict>
       </dict>
       <key>number-hex</key>

--- a/grammars/src/MagicPython.syntax.yaml
+++ b/grammars/src/MagicPython.syntax.yaml
@@ -624,7 +624,6 @@ repository:
     captures:
       '1': {name: storage.type.imaginary.number.python}
       '2': {name: invalid.illegal.dec.python}
-      '3': {name: invalid.illegal.dec.python}
 
   number-hex:
     name: constant.numeric.hex.python


### PR DESCRIPTION
also validated this against oniguruma via [onigurumacffi](https://github.com/asottile/onigurumacffi)

```
>>> REG = '''\
...        (?x)
...          (?<![\w\.])(?:
...              [1-9](?: _?[0-9] )*
...              |
...              0+
...              |
...              [0-9](?: _?[0-9] )* ([jJ])
...              |
...              0 ([0-9]+)(?![eE\.])
...          )\b
... '''
>>> import onigurumacffi
>>> reg = onigurumacffi.compile(REG)
>>> reg.number_of_captures()
2
```