### PR TITLE
Github doesn't seem to use MP for highlighter tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ with [Sublime Text](http://www.sublimetext.com), [Atom](http://atom.io) and
 [Visual Studio Code](http://code.visualstudio.com). It is meant to be a drop-in
 replacement for the default Python package.
 
-We are proud to say that MagicPython is used by GitHub to highlight Python.
-
 **Attention VSCode users**: MagicPython is used as the _default_
 Python highlighter in Visual Studio Code. Don't install it unless you
 want or need the cutting edge version of it. You will likely see no


### PR DESCRIPTION
MagicPython is still used by Linguist, but the actual syntax
hightlighting seems to be driven by something else now.  Thus, remove
the outdated statement from the README.

Closes: #225